### PR TITLE
Multifile server

### DIFF
--- a/server.js
+++ b/server.js
@@ -84,20 +84,40 @@ function isValidDir(dir) {
 
 /**
  * Asynchronously creates a nested JS object matching the file structure of the given directory,
- * where folders have children iff they have subdirectories.
- * Does not include the parameter directory. Does not include any leaf directory that is missing
- * a metadata.json or quaternion_data.dat file.
+ * subdirectories are only added to the file tree if (1) they contain a `metadata.json` file or 
+ * (2) one of their children has already been added to the file tree.
+ * Does not include the parameter directory. 
  * @example 
- * // Returns [{name: child1, id: child1}, {name: child2, id: child2, children: [{name: foo, id: child2/grandchild}]}]
- * // for the following file structure:
- * // parent
- * // |-- child1
- * // |    `-- metadata.json (contains no "displayName:" field)
- * // |    `-- quaternion_data.dat
- * // `-- child2
- * //      `-- grandchild
- * //          |-- metadata.json (contains "displayName": "foo")
- * //          `-- quaternion_data.dat
+ * 
+ *    Returns [{
+ *      name: child1, 
+ *      id: child1,
+ *      children: [{
+ *          name: original-filename.dat, 
+ *          id: child1/original-filename.dat}
+ *    ]}, {
+ *      name: child2, 
+ *      id: child2, 
+ *      children: [{
+ *          name: foo, 
+ *          id: child2/grandchild
+ *          children: [{
+ *              name: bar.dat,
+ *              id: child2/grandchild/bar.dat
+ *          }]
+ *      }]
+ *    }]
+ * 
+ *    for the following file structure:
+ * 
+ *    parent
+ *    |-- child1
+ *    |    `-- metadata.json (contains no "displayName:" field)
+ *    |    `-- original-filename.dat
+ *    `-- child2
+ *         `-- grandchild
+ *             |-- metadata.json (contains "displayName": "foo")
+ *             `-- bar.dat
  * getDirStructure("parent", false)
  * @param {String} dir The name of the directory to encode.
  * @param {String} displayDirname The prefix to the filename in the ID field for each subdirectory.

--- a/server.js
+++ b/server.js
@@ -105,13 +105,22 @@ function isValidDir(dir) {
  */
  function getDirStructure(dir, displayDirname) {
     return new Promise((myResolve, myReject) => {
-        let childDirectories = [];
+        let thisDirElements = [];
         fs.readdir(dir, {withFileTypes: true}, (err, fileList) => {
             if (err) {
                 myReject(err);
                 return; 
             }
             let promises = [];
+
+            // First check if there is a metadata file
+            let containsMetadata = false;
+            fileList.forEach((file) => {
+                if (!file.isDirectory() && file.name == "metadata.json")
+                    containsMetadata = true;
+            })
+            
+            // Then actually go through the folder's items
             fileList.forEach((file) => {
                 if (file.isDirectory()) {
                     let dirObj = {
@@ -120,22 +129,32 @@ function isValidDir(dir) {
                         children: null,
                     }
                     let dirStructPromise = getDirStructure(dir+'/'+file.name, displayDirname+'/'+file.name);
-                    dirStructPromise.then((subDir) => {
-                        dirObj.children = subDir;
+                    dirStructPromise.then((subDirElements) => {
+                        if (subDirElements.length > 0) {
+                            dirObj.children = subDirElements;
+                            thisDirElements.push(dirObj)
+                        }
                     });
                     let displayNamePromise = getFileDisplayName(dir+'/'+file.name);
                     displayNamePromise.then((displayName) => {
                         dirObj.name = (displayName === null) ? file.name : displayName;
                     });
-                    let validDirPromise = isValidDir(dir+'/'+file.name);
-                    validDirPromise.then((valid) => {
-                        if (valid) { childDirectories.push(dirObj); }
-                    })
-                    promises.push(dirStructPromise, displayNamePromise, validDirPromise);
+                    promises.push(dirStructPromise, displayNamePromise);
+                } else {
+                    // Not a directory
+                    if (containsMetadata) {
+                        if (file.name !== "metadata.json") {
+                            thisDirElements.push({
+                                name: file.name,
+                                id: displayDirname + '/' + file.name,
+                                children: null,
+                            })
+                        }
+                    }
                 }
             });
             Promise.all(promises).then(() => {
-                myResolve(childDirectories.length > 0 ? childDirectories : null);
+                myResolve(thisDirElements);
             });
         });
     });
@@ -242,7 +261,7 @@ function writeUploadedFile(data, metadata, filepath) {
     return new Promise((myResolve, myReject) => {
         fs.mkdir(filepath, {recursive: true}, (err) => {
             if (err) {
-                if (VERBOSE_OUTPUT) console.log("Error occured when trying to make new directory!")
+                if (VERBOSE_OUTPUT) console.log("Error occurred when trying to make new directory!")
                 myReject(err); // If I handle this somehow, then this can just return Promise.all below instead
                 return;
             }
@@ -305,12 +324,18 @@ function cleanFilename(targetFile) {
     return targetFile;
 }
 
+
+// Remove the file name and replace it with `metadata.json`
+function getMetadataPath(originalPath) {
+    return originalPath.substr(0, originalPath.lastIndexOf("/") + 1) + "metadata.json"
+}
+
 function fileAvailable(targetFile) {
     targetFile = cleanFilename(targetFile);
     let fileRoot = `${__dirname}/files`;
     if (VERBOSE_OUTPUT) console.log("File root: " + fileRoot);
-    let dataFilePath = `${fileRoot}/${targetFile}/quaternion_data.dat`;
-    let metadataPath = `${fileRoot}/${targetFile}/metadata.json`;
+    let dataFilePath = `${fileRoot}/${targetFile}`;
+    let metadataPath = `${fileRoot}/${getMetadataPath(targetFile)}`
     if (VERBOSE_OUTPUT) console.log(`Checking for available files: ${dataFilePath}, ${metadataPath}`);
     return (fs.existsSync(dataFilePath) && fs.existsSync(metadataPath));
 }
@@ -333,10 +358,10 @@ app.get("/api/uploadedfiles", (req, res) => {
     let filePath;
     switch (req.query.type) {
         case ('data'):
-            filePath = `${fileRoot}/${targetFile}/quaternion_data.dat`
+            filePath = `${fileRoot}/${targetFile}`
             break;
         case ('metadata'):
-            filePath = `${fileRoot}/${targetFile}/metadata.json`
+            filePath = `${fileRoot}/${getMetadataPath(targetFile)}`
             break;
         default:
             res.sendStatus(400);


### PR DESCRIPTION
This pull request modifies the way the server retrieves files by allowing it to access multiple different files within the same folder, so long as that folder contains a `metadata.json` file. 

The `displayName` field of `metadata.json` is still used to generate the folder name that is shown to the end user. However, additional nodes will now exist inside of that node in the file tree as seen by the end user (previously, the user only saw directories and could click on any directory name containing `metadata.json`). These additional names will contain the original file names as uploaded by the user.

This pull request would allow there to be a single `metadata.json` file for datasets that used the same sensor layout for all trials. Additionally, this pull request solves the known bug mentioned in the fourth bullet of #2 by only adding directories that contain (1) a `metadata.json` file or (2) a valid subdirectory.

If this pull request has been accepted, it would be optimal to modify the directory structure on the server (as well as possibly the code that saves uploaded files) so that the file tree does not contain unnecessary `quaternion.dat` files.