### PR TITLE
Include all data lines, add global quaternions to tinker tool

### DIFF
--- a/src/components/QuaternionSelect.js
+++ b/src/components/QuaternionSelect.js
@@ -46,11 +46,6 @@ export default function QuaternionSelect({ onChange, onRemove, value }) {
         onChange(quatFromAxisAngle(axisMap[axisStringFromQuat(value)], newAngle));
     }
 
-    // React.useEffect(() => {
-    //     if (!onChange) { return; }
-    //     onChange(quatFromAxisAngle(axisMap[axisFromQuat(value)], angle));
-    // }, []);
-
     function quatFromAxisAngle(axis, angle) {
         return {
           w: Math.cos(angle / 2),

--- a/src/components/upload-screen/SimpleSceneVis.js
+++ b/src/components/upload-screen/SimpleSceneVis.js
@@ -38,7 +38,7 @@ const axisMap = {
  * @param {Object} props
  * @param {BasicVisualizerObject} props.visualizer
  */
-export default function DialogSelect(props) {
+export default function SimpleSceneVis(props) {
 
   const classes = useStyles();
 
@@ -96,7 +96,6 @@ export default function DialogSelect(props) {
   React.useEffect(() => {
     let newQ = quatFromAxisAngle(axisMap[axis], angle);
     let threeQuat = new THREE.Quaternion(newQ.x, newQ.y, newQ.z, newQ.w);
-    // props.visualizer.acceptData({ RUA: threeQuat });
   }, [axis, angle])
 
   const handleChangeAngle = (event, newValue) => {

--- a/src/components/visualizer-screen/viewport-workers/NetOps.js
+++ b/src/components/visualizer-screen/viewport-workers/NetOps.js
@@ -185,8 +185,12 @@ export function subscribeToFile(props, mySelectedFile) {
             //When we get the files, we should use the original code to assign them as quaternions (after decoding from metadata)
             let inputArray = responses[0].split("\n");
             let linesArray = [];
-    
-            for (let i = 2; i < inputArray.length - 1; i++) {
+
+            const COMMENT_DELIMITER = '#';
+            const MIN_ITEMS_PER_LINE = 4;
+            for (let i = 0; i < inputArray.length - 1; i++) {
+                const lineItems = inputArray[i].split(" ").filter(item => item !== '\r');
+                if (lineItems.length < MIN_ITEMS_PER_LINE || lineItems[0] === COMMENT_DELIMITER) { continue; }
                 linesArray.push(inputArray[i].split(" ").filter(item => item !== '\r'));
             }
     


### PR DESCRIPTION
Solves #6 as it appears in the Opportunity dataset files by skipping '#'-delimited lines and lines with fewer than 4 whitespace-separated tokens when copying incoming file data to the `data` ref. See NetOps.js starting [here](https://github.com/jpiland16/hmv_test/blob/ea59c26377621e15d5c5dbe56c1ecbcd8732819b/src/components/visualizer-screen/viewport-workers/NetOps.js#L189) for the implementation. *Note*: You can easily get around this fix with a data line containing many whitespace-separated nonsense tokens, like 'a a a a a'. That isn't a new problem, though.

I've also bundled in some changes to the [Metadata tinkerer](https://github.com/jpiland16/hmv_test/blob/include-all-data-lines/src/components/MetadataTinkerer.js). It now more accurately mirrors how the data will look on the model, and it allows a global quaternion--I hadn't realized their importance until I tried configuring the Opportunity dataset without using a global transform.